### PR TITLE
Add staticArray!immutable example, add ddoc warning & bug link

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -465,6 +465,15 @@ unittest
  *      arr = An array literal.
  *
  * Returns: A static array of size `arr.length`.
+ *
+ * Warning:
+ * Do not initialize a dynamic array with a call to staticArray.
+ * The dynamic array slice would point to stack memory no longer in use.
+ * Instead define the static array first using type inference (or `int[4]`).
+ * ---
+ * int[] invalid = [1,2,3,4].staticArray; // Wrong
+ * ---
+ * See $(LINK2 http://issues.dlang.org/show_bug.cgi?id=12625, Issue 12625).
  */
 @nogc T[n] staticArray(T, size_t n)(T[n] arr)
 {
@@ -472,22 +481,24 @@ unittest
     return arr;
 }
 
-///
+/// Array size and type can be inferred:
 @safe @nogc pure nothrow unittest
 {
-    auto arr = [1,2,3,4].staticArray;         // no need to declare size
+    auto arr = [1,2,3,4].staticArray;
     static assert(is(typeof(arr) == int[4])); // arr is a static array
     assert(arr == [1,2,3,4]);
-
-    version(Bug)
-    {
-        // Do not initialize a dynamic array with a call to staticArray.
-        // `invalid` will be a slice to stack memory no longer in use.
-        // Instead use type inference (or int[4]).
-        int[] invalid = [1,2,3,4].staticArray;
-    }
 }
 
+// dmd doesn't support inference of n, but not T for staticArray!immutable
+// http://issues.dlang.org/show_bug.cgi?id=15890
+/// The element type can also be supplied:
+@safe @nogc pure nothrow unittest
+{
+    auto arr = [1,2].staticArray!(immutable int, 2);
+    static assert(is(typeof(arr) == immutable(int)[2]));
+    assert(arr == [1,2].staticArray);
+}
+    
 /**
 Returns a newly allocated associative _array from a range of key/value tuples.
 Params: r = An input range of tuples of keys and values.


### PR DESCRIPTION
Added example with `staticArray!(immutable int, 2)`, supplying `n` as a workaround.
I decided to move the `version(Bug)` code into a ddoc warning, added a bug link too.
